### PR TITLE
feat: kafka 사용해 댓글수 집계에 반영하는 로직 구현

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,3 +15,25 @@ services:
     container_name: comment-redis
     ports:
       - "6379:6379"
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: comment-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: comment-kafka
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    ports:
+      - "9092:9092"

--- a/src/main/java/com/repick/comment/domain/CommentEvent.java
+++ b/src/main/java/com/repick/comment/domain/CommentEvent.java
@@ -1,0 +1,14 @@
+package com.repick.comment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentEvent {
+    private Long postId;
+    private Long commentId;
+    private String action;  // "CREATE", "DELETE"
+}

--- a/src/main/java/com/repick/comment/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/repick/comment/kafka/KafkaTopicConfig.java
@@ -1,0 +1,29 @@
+package com.repick.comment.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic commentTopic() {
+        return new NewTopic("comment-topic", 1, (short) 1); // 파티션 수: 1, 복제본 수: 1
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #12 

## 📝 요약(Summary)

kafka 사용해 댓글에서 작성, 삭제 시 메시지를 발송하고 게시글 서버에서 메시지를 받으면 댓글수 증감 로직 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/37ffeb40-ae22-4068-afd1-8274c24ea0e5)
![image](https://github.com/user-attachments/assets/b5672d08-ff8d-4a4a-988a-2a3671abd52c)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
